### PR TITLE
update WebUI to the proper scheme per unraid

### DIFF
--- a/librephotos.xml
+++ b/librephotos.xml
@@ -35,7 +35,7 @@ What does it use?&#xD;
     Reverse geocoding: Mapbox: You need to have an API key. First 50,000 geocode lookups are free every month.&#xD;
 </Overview>
   <Category>Cloud: MediaApp:Photos MediaServer:Photos Status:Beta</Category>
-  <WebUI>http://[IP]:[PORT:3000]</WebUI>
+  <WebUI>http://[IP]:[PORT:80]</WebUI>
   <TemplateURL/>
   <Icon>https://github.com/LibrePhotos/librephotos-frontend/blob/88efbd434f63e8722c085629c57c85f59dce240b/public/logo-inverted.png</Icon>
   <ExtraParams/>


### PR DESCRIPTION
The WebUI port must be matched to the containers port, not the host port, this will allow users to edit only the host port mapping and still have the WebUI automatically sorted out by unraid admin panel.

This should fix the error in the CA about missing port mapping in container.

Check https://forums.unraid.net/topic/91621-docker-template-errors/ for more info.